### PR TITLE
Fix installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Install
 
 ```
-asdf plugin-add gradle https://github.com/joschi/asdf-gradle-profiler.git
+asdf plugin-add gradle-profiler https://github.com/joschi/asdf-gradle-profiler.git
 ```
 
 ## Use


### PR DESCRIPTION
The plugin should be installed under `gradle-profiler` not `gradle` which is already
used by https://github.com/rfrancis/asdf-gradle.