### PR TITLE
gradle-profiler is distributed via Maven Central

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,7 +2,7 @@
 
 function download_url() {
   local version=$1
-  echo "https://repo.gradle.org/gradle/ext-releases-local/org/gradle/profiler/gradle-profiler/${version}/gradle-profiler-${version}.zip"
+  echo "https://repo1.maven.org/maven2/org/gradle/profiler/gradle-profiler/${version}/gradle-profiler-${version}.zip"
 }
 
 fail() {


### PR DESCRIPTION
This was changed before the 0.17 release.

This also fixes a bug in the plugin because `list-all` queries GitHub releases
which reports 0.18.0 as the last release but repo.gradle.org does not have this
version.
As a follow up `list-all` should be changed to get the list of all released from
the same source (Maven Central).